### PR TITLE
 Supress GTK warning messages while running in CLI #34

### DIFF
--- a/bleachbit/Cleaner.py
+++ b/bleachbit/Cleaner.py
@@ -24,11 +24,7 @@ Perform (or assist with) cleaning operations.
 
 
 import glob
-try:
-    import gtk
-    HAVE_GTK = True
-except:
-    HAVE_GTK = False
+import warnings
 import os.path
 import re
 import sys
@@ -48,6 +44,12 @@ from Common import _
 from FileUtilities import children_in_directory
 from Options import options
 
+warnings.simplefilter("ignore", Warning) # Supress GTK warning messages while running in CLI #34 
+try:
+    import gtk
+    HAVE_GTK = True
+except:
+    HAVE_GTK = False
 
 # a module-level variable for holding cleaners
 backends = {}


### PR DESCRIPTION
Using Python built in method in the standard library for supressing warnings.