### PR TITLE
Fulfill Fedora license file location change

### DIFF
--- a/bleachbit/Common.py
+++ b/bleachbit/Common.py
@@ -68,8 +68,8 @@ license_filenames = ('/usr/share/common-licenses/GPL-3',  # Debian, Ubuntu
                          bleachbit_exe_path, 'COPYING'),  # Microsoft Windows
                      '/usr/share/doc/bleachbit-' + APP_VERSION +
                      '/COPYING',  # CentOS, Fedora, RHEL
-                     '/usr/share/doc/packages/bleachbit/COPYING',
-                     # OpenSUSE 11.1
+                     '/usr/share/licenses/bleachbit/COPYING',  # Fedora 21+, RHEL 7+
+                     '/usr/share/doc/packages/bleachbit/COPYING',  # OpenSUSE 11.1
                      '/usr/share/doc/bleachbit/COPYING',  # Mandriva
                      '/usr/pkg/share/doc/bleachbit/COPYING',  # NetBSD 5
                      '/usr/share/licenses/common/GPL3/license.txt')  # Arch Linux


### PR DESCRIPTION
Fedora bleachbit maintainer here:

Owing to the change at https://fedoraproject.org/wiki/Changes/Use_license_macro_in_RPMs_for_packages_in_Cloud_Image, this path should be included.

It's intended for Fedora 21+ and RHEL 7+.