### PR TITLE
Localizations simplification

### DIFF
--- a/bleachbit/Unix.py
+++ b/bleachbit/Unix.py
@@ -282,14 +282,14 @@ class Locales:
         if not os.path.isdir(path):
             return
 
-        pre = ''
-        post = ''
+        pre = None
+        post = None
         if 'regexfilter' == xmldata.nodeName:
             pre = xmldata.getAttribute('prefix') or ''
             post = xmldata.getAttribute('postfix') or ''
         if 'path' == xmldata.nodeName:
             userfilter = xmldata.getAttribute('filter')
-            if not userfilter and not xmldata.hasChildNodes:
+            if not userfilter and not xmldata.hasChildNodes():
                 userfilter = '*'
             if userfilter:
                 if 1 != userfilter.count('*'):
@@ -302,7 +302,7 @@ class Locales:
             for child in xmldata.childNodes:
                 for (locale, subpath) in Locales.handle_path(path, child):
                     yield (locale, subpath)
-        if pre or post:
+        if pre is not None and post is not None:
             try:
                 re.compile(pre)
                 re.compile(post)

--- a/cleaners/localizations.xml
+++ b/cleaners/localizations.xml
@@ -2,7 +2,12 @@
 <cleaner id="localizations" os="linux">
   <label>Localizations</label>
   <localizations>
+  <!-- Here are paths which contain localizations. Each <path> is relative to
+       the parent element, so <path location="/usr"><path location="share"/></path>
+		 effects elements in /usr/share.-->
     <path location="/usr/lib">
+	   <!-- This filter deletes /usr/lib/chromium/locales/*.pak, where * is every
+		     valid locale not specifically excluded in the configuration.-->
       <path location="chromium/locales" filter="*.pak"/>
       <path location="libreoffice/share">
         <path location="autocorr" filter="acor_*.dat"/>
@@ -10,6 +15,8 @@
       </path>
     </path>
     <path location="/usr/share">
+	   <!-- A <path> element without children and an explicit filter-attribute
+		     defaults to filter="*"-->
       <path location="anki/locale"/>
       <path location="apps/ksgmltools/customization"/>
       <path location="calendar"/>
@@ -31,7 +38,12 @@
       </path>
       <path location="qt4/translations" filter="qt_*.qm"/>
       <path location="qt/translations">
+		  <!-- <regexfilter> enables filtering files/folders with 2 regular expressions.
+		       This deletes every file matching |prefix | locale   | postfix, e.g.
+				                                  qt_help_hu_HU.UTF-8.qm
+             This can only be used to delete entries in the current <path> -->
         <regexfilter prefix="qt(_|script|_help|base|xmlpatterns)_" postfix="\.qm"/>
+		  <!-- You can also specify multiple <regexfilter>s within a single path -->
         <regexfilter prefix="(linguist|designer)_" postfix="\.qm"/>
       </path>
       <path location="speedcrunch/books"/>

--- a/cleaners/localizations.xml
+++ b/cleaners/localizations.xml
@@ -36,15 +36,17 @@
       <path location="mscore-2.0/locale">
         <regexfilter prefix="(instruments|mscore|qt)_" postfix="\.qm"/>
       </path>
-      <path location="qt4/translations" filter="qt_*.qm"/>
+      <path location="qt4/translations">
+        <regexfilter prefix="\w*_" postfix="\.qm"/>
+      </path>
       <path location="qt/translations">
         <!-- <regexfilter> enables filtering files/folders with 2 regular expressions.
              This deletes every file matching |prefix | locale   | postfix, e.g.
                                               qt_help_hu_HU.UTF-8.qm
              This can only be used to delete entries in the current <path> -->
-        <regexfilter prefix="qt(_|script|_help|base|xmlpatterns)_" postfix="\.qm"/>
+        <regexfilter prefix="q[\w_]*" postfix="\.qm"/>
         <!-- You can also specify multiple <regexfilter>s within a single path -->
-        <regexfilter prefix="(linguist|designer)_" postfix="\.qm"/>
+        <regexfilter prefix="(linguist|designer|assistant)_" postfix="\.qm"/>
       </path>
       <path location="speedcrunch/books"/>
       <path location="texmaker/" filter="*.dic">

--- a/cleaners/localizations.xml
+++ b/cleaners/localizations.xml
@@ -27,13 +27,17 @@
       <path location="lyx/examples"/>
       <path location="man"/>
       <path location="mscore-2.0/locale">
-        <path location="." filter="instruments_*.qm"/>
-        <path location="." filter="mscore_*.qm"/>
-        <path location="." filter="qt_*.qm"/>
+        <regexfilter prefix="(instruments|mscore|qt)_" postfix="\.qm"/>
       </path>
       <path location="qt4/translations" filter="qt_*.qm"/>
+      <path location="qt/translations">
+        <regexfilter prefix="qt(_|script|_help|base|xmlpatterns)_" postfix="\.qm"/>
+        <regexfilter prefix="(linguist|designer)_" postfix="\.qm"/>
+      </path>
       <path location="speedcrunch/books"/>
-      <path location="texmaker/" filter="*.dic"/>
+      <path location="texmaker/" filter="*.dic">
+        <regexfilter prefix="(texmaker|qt)_" postfix="\.qm"/>
+      </path>
       <path location="vim/vim74/lang" filter="menu_*.vim"/>
       <path location="vim/vim74/lang"/>
       <path location="X11/locale"/>

--- a/cleaners/localizations.xml
+++ b/cleaners/localizations.xml
@@ -4,10 +4,10 @@
   <localizations>
   <!-- Here are paths which contain localizations. Each <path> is relative to
        the parent element, so <path location="/usr"><path location="share"/></path>
-		 effects elements in /usr/share.-->
+       effects elements in /usr/share.-->
     <path location="/usr/lib">
-	   <!-- This filter deletes /usr/lib/chromium/locales/*.pak, where * is every
-		     valid locale not specifically excluded in the configuration.-->
+      <!-- This filter deletes /usr/lib/chromium/locales/*.pak, where * is every
+           valid locale not specifically excluded in the configuration.-->
       <path location="chromium/locales" filter="*.pak"/>
       <path location="libreoffice/share">
         <path location="autocorr" filter="acor_*.dat"/>
@@ -15,8 +15,8 @@
       </path>
     </path>
     <path location="/usr/share">
-	   <!-- A <path> element without children and an explicit filter-attribute
-		     defaults to filter="*"-->
+      <!-- A <path> element without children and an explicit filter-attribute
+           defaults to filter="*"-->
       <path location="anki/locale"/>
       <path location="apps/ksgmltools/customization"/>
       <path location="calendar"/>
@@ -38,12 +38,12 @@
       </path>
       <path location="qt4/translations" filter="qt_*.qm"/>
       <path location="qt/translations">
-		  <!-- <regexfilter> enables filtering files/folders with 2 regular expressions.
-		       This deletes every file matching |prefix | locale   | postfix, e.g.
-				                                  qt_help_hu_HU.UTF-8.qm
+        <!-- <regexfilter> enables filtering files/folders with 2 regular expressions.
+             This deletes every file matching |prefix | locale   | postfix, e.g.
+                                              qt_help_hu_HU.UTF-8.qm
              This can only be used to delete entries in the current <path> -->
         <regexfilter prefix="qt(_|script|_help|base|xmlpatterns)_" postfix="\.qm"/>
-		  <!-- You can also specify multiple <regexfilter>s within a single path -->
+        <!-- You can also specify multiple <regexfilter>s within a single path -->
         <regexfilter prefix="(linguist|designer)_" postfix="\.qm"/>
       </path>
       <path location="speedcrunch/books"/>

--- a/doc/cleaner_markup_language.xsd
+++ b/doc/cleaner_markup_language.xsd
@@ -154,10 +154,16 @@
   </xs:element>
   <xs:element name="path">
     <xs:complexType>
-      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
         <xs:element ref="path"/>
-      </xs:sequence>
-      <xs:attribute name="location" type="xs:string" use="required"/>
+        <xs:element name="regexfilter">
+          <xs:complexType>
+            <xs:attribute name="prefix" type="xs:string" use="optional"/>
+            <xs:attribute name="postfix" type="xs:string" use="optional"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+      <xs:attribute name="location" type="xs:string" use="optional" default="."/>
       <xs:attribute name="filter" type="xs:string" use="optional" default="*"/>
     </xs:complexType>
   </xs:element>

--- a/tests/TestUnix.py
+++ b/tests/TestUnix.py
@@ -84,7 +84,7 @@ class UnixTestCase(unittest.TestCase):
             m = regex.match(test[0])
             self.assertEqual(m.group("locale"), test[1])
         for test in ['default','C','English']:
-            self.assertIsNone(regex.match('test'))
+            self.assertTrue(regex.match('test') is None)
 
     def test_localization_paths(self):
         """Unit test for localization_paths()"""

--- a/tests/TestUnix.py
+++ b/tests/TestUnix.py
@@ -69,44 +69,22 @@ class UnixTestCase(unittest.TestCase):
         exe = os.path.basename(os.path.realpath(sys.executable))
         self.assertTrue(is_running(exe))
 
-    def test_locale_to_language(self):
+    def test_locale_regex(self):
         """Unit test for locale_to_language()"""
         tests = [('en', 'en'),
                  ('en_US', 'en'),
                  ('en_US@piglatin', 'en'),
                  ('en_US.utf8', 'en'),
-                 ('klingon', 'klingon'),
                  ('pl.ISO8859-2', 'pl'),
                  ('sr_Latn', 'sr'),
                  ('zh_TW.Big5', 'zh')]
+        import re
+        regex = re.compile('^'+Locales.localepattern+'$')
         for test in tests:
-            self.assertEqual(locale_to_language(test[0]), test[1])
-
-        self.assertRaises(ValueError, locale_to_language, 'default')
-        self.assertRaises(ValueError, locale_to_language, 'C')
-        self.assertRaises(ValueError, locale_to_language, 'English')
-
-    def test_locale_globex(self):
-        """Unit test for locale_globex"""
-
-        locale = locale_globex('/bin/ls', '(ls)$').next()
-        self.assertEqual(locale, ('ls', '/bin/ls'))
-
-        fakepath = '/usr/share/omf/gedit/gedit-es.omf'
-
-        def test_yield(pathname, regex):
-            """Replacement for globex()"""
-            yield fakepath
-
-        old_globex = FileUtilities.globex
-        FileUtilities.globex = test_yield
-
-        func = locale_globex('/usr/share/omf/*/*-*.omf', '-([a-z]{2}).omf$')
-        actual = func.next()
-        expect = ('es', fakepath)
-        self.assertEqual(
-            actual, expect, "Expected '%s' but got '%s'" % (expect, actual))
-        FileUtilities.globex = old_globex
+            m = regex.match(test[0])
+            self.assertEqual(m.group("locale"), test[1])
+        for test in ['default','C','English']:
+            self.assertIsNone(regex.match('test'))
 
     def test_localization_paths(self):
         """Unit test for localization_paths()"""
@@ -123,13 +101,6 @@ class UnixTestCase(unittest.TestCase):
             counter += 1
         self.assert_(
             counter > 0, 'Zero files deleted by localization cleaner.  This may be an error unless you really deleted all the files.')
-
-    def test_native_name(self):
-        """Unit test for native_name()"""
-        tests = [('en', 'English'),
-                 ('es', 'Español')]
-        for test in tests:
-            self.assertEqual(self.locales.native_name(test[0]), test[1])
 
     def test_rotated_logs(self):
         """Unit test for rotated_logs()"""


### PR DESCRIPTION
Since the Qt localizations for Qt programs are in separate folders, I added support for regular expressions in filters via the new `<regexfilter>`-tag.
The previous filters (`<path location="." filter="foo*.bar"/>`) are automatically rewritten to regular expressions (here equivalent to `<regexfilter prefix="foo" postfix="\.bar"/>`), so existing filters don't need to be changed.

I already added some examples with comments in localizations.xml, someone with a bunch of Qt applications installed should contribute some more filters.