### PR TITLE
Add option for preferred size prefixes (#103)

### DIFF
--- a/bleachbit/FileUtilities.py
+++ b/bleachbit/FileUtilities.py
@@ -92,31 +92,39 @@ def __random_string(length):
 
 
 def bytes_to_human(bytes_i):
-    """Display a file size in human terms (megabytes, etc.) using SI standard"""
+    """Display a file size in human terms (megabytes, etc.) using preferred standard (SI or IEC)"""
 
-    storage_multipliers = {1000 ** 5: 'PB', 1000 ** 4: 'TB',
-                           1000 ** 3: 'GB', 1000 ** 2: 'MB', 1000: 'kB', 1: 'B'}
+    if bytes_i < 0:
+        return '-' + bytes_to_human(bytes_i)
+
+    from Options import options
+    if options.get('units_iec'):
+        prefixes = ['','Ki','Mi','Gi','Ti','Pi']
+        base = 1024.0
+    else:
+        prefixes = ['','k','M','G','T','P']
+        base = 1000.0
 
     assert(isinstance(bytes_i, (int, long)))
 
     if 0 == bytes_i:
         return "0"
 
-    if bytes_i >= 1000 ** 3:
+    if bytes_i >= base ** 3:
         decimals = 2
-    elif bytes_i >= 1000:
+    elif bytes_i >= base:
         decimals = 1
     else:
         decimals = 0
 
-    for key in sorted(storage_multipliers.keys(), reverse=True):
-        if bytes_i >= key:
-            abbrev = round((1.0 * bytes_i) / key, decimals)
-            suf = storage_multipliers[key]
-            return locale.str(abbrev) + suf
-
-    if bytes_i < 0:
-        return "-" + bytes_to_human(abs(bytes_i))
+    for exponent in range(0,len(prefixes)-1):
+        if bytes_i < base:
+            abbrev = round(bytes_i, decimals)
+            suf = prefixes[exponent]
+            return locale.str(abbrev) + suf + 'B'
+        else:
+            bytes_i /= base
+    return 'A lot.'
 
 
 def children_in_directory(top, list_directories=False):

--- a/bleachbit/FileUtilities.py
+++ b/bleachbit/FileUtilities.py
@@ -95,7 +95,7 @@ def bytes_to_human(bytes_i):
     """Display a file size in human terms (megabytes, etc.) using preferred standard (SI or IEC)"""
 
     if bytes_i < 0:
-        return '-' + bytes_to_human(bytes_i)
+        return '-' + bytes_to_human(-bytes_i)
 
     from Options import options
     if options.get('units_iec'):

--- a/bleachbit/GuiPreferences.py
+++ b/bleachbit/GuiPreferences.py
@@ -178,6 +178,11 @@ class PreferencesDialog:
             'toggled', self.__toggle_callback, 'delete_confirmation')
         vbox.pack_start(cb_popup, False)
 
+        # Use base 1000 oder 1024?
+        cb_units_iec = gtk.CheckButton(_("Use IEC sizes (1 KiB = 1024 bytes) instead of SI (1 kB = 1000 bytes)"))
+        cb_units_iec.set_active(options.get("units_iec"))
+        cb_units_iec.connect('toggled', self.__toggle_callback, 'units_iec')
+        vbox.pack_start(cb_units_iec, False)
         return vbox
 
     def __drives_page(self):

--- a/bleachbit/Options.py
+++ b/bleachbit/Options.py
@@ -36,7 +36,7 @@ if 'nt' == os.name:
 
 
 boolean_keys = ['auto_hide', 'auto_start', 'check_beta',
-                'check_online_updates', 'first_start', 'shred', 'exit_done', 'delete_confirmation']
+                'check_online_updates', 'first_start', 'shred', 'exit_done', 'delete_confirmation', 'units_iec']
 if 'nt' == os.name:
     boolean_keys.append('update_winapp2')
 
@@ -207,6 +207,7 @@ class Options:
         self.__set_default("shred", False)
         self.__set_default("exit_done", False)
         self.__set_default("delete_confirmation", True)
+        self.__set_default("units_iec", False)
 
         if 'nt' == os.name:
             self.__set_default("update_winapp2", False)


### PR DESCRIPTION
This adds an option to switch between IEC and SI prefixes (see #103).
It also fixes the case where no value was returned if more than 1 petabytes were freed.