### PR TITLE
Don't add a dummy option to localizations.xml (fixes #110)

### DIFF
--- a/bleachbit/CleanerML.py
+++ b/bleachbit/CleanerML.py
@@ -180,8 +180,6 @@ class CleanerML:
         for localization_node in localization_nodes:
             for child_node in localization_node.childNodes:
                 Unix.locales.add_xml(child_node)
-        # Add a dummy action so the file isn't reported as unusable
-        self.cleaner.add_action('localization', ActionProvider(None))
 
 
 def list_cleanerml_files(local_only=False):


### PR DESCRIPTION
With `auto_hide` disabled, the dummy action is shown in the menu but doesn't actually work.