### PR TITLE
 Update Epiphany Cleaner

### DIFF
--- a/cleaners/epiphany.xml
+++ b/cleaners/epiphany.xml
@@ -30,7 +30,6 @@
     <action command="delete" search="file" path="~/.gnome2/epiphany/ephy-favicon-cache.xml"/>
     <action command="delete" search="walk.files" path="~/.gnome2/epiphany/favicon_cache/"/>
     <action command="delete" search="walk.files" path="~/.gnome2/epiphany/mozilla/epiphany/Cache/"/>
-    <action command="delete" search="file" path="~/.cache/epiphany-browser/icondatabase/WebpageIcons.db"/>
     <action command="delete" search="walk.files" path="~/.cache/epiphany-browser/"/>
   </option>
   <option id="cookies">

--- a/cleaners/epiphany.xml
+++ b/cleaners/epiphany.xml
@@ -63,6 +63,6 @@
   <option id="dom">
     <label>DOM Storage</label>
     <description>Delete HTML5 cookies</description>
-    <action command="delete" search="walk.file" path="~/.local/share/webkitgtk/localstorage/"/>
+    <action command="delete" search="walk.files" path="~/.local/share/webkitgtk/localstorage/"/>
   </option>
 </cleaner>

--- a/cleaners/epiphany.xml
+++ b/cleaners/epiphany.xml
@@ -30,6 +30,8 @@
     <action command="delete" search="file" path="~/.gnome2/epiphany/ephy-favicon-cache.xml"/>
     <action command="delete" search="walk.files" path="~/.gnome2/epiphany/favicon_cache/"/>
     <action command="delete" search="walk.files" path="~/.gnome2/epiphany/mozilla/epiphany/Cache/"/>
+    <action command="delete" search="file" path="~/.cache/epiphany-browser/icondatabase/WebpageIcons.db"/>
+    <action command="delete" search="walk.files" path="~/.cache/epiphany-browser/"/>
   </option>
   <option id="cookies">
     <label>Cookies</label>
@@ -37,6 +39,7 @@
     <action command="delete" search="file" path="~/.gnome2/epiphany/mozilla/epiphany/cookies.txt"/>
     <action command="delete" search="file" path="~/.gnome2/epiphany/mozilla/epiphany/cookies.sqlite"/>
     <action command="delete" search="file" path="~/.gnome2/epiphany/mozilla/epiphany/cookies.sqlite-journal"/>
+    <action command="delete" search="file" path="~/.config/epiphany/cookies.sqlite"/>
   </option>
   <option id="passwords">
     <label>Passwords</label>
@@ -51,5 +54,15 @@
     <action command="delete" search="file" path="~/.gnome2/epiphany/mozilla/epiphany/places.sqlite"/>
     <action command="delete" search="file" path="~/.gnome2/epiphany/mozilla/epiphany/places.sqlite-journal"/>
     <action command="delete" search="file" path="~/.gnome2/epiphany/ephy-history.xml"/>
+    <action command="delete" search="file" path="~/.config/epiphany/bookmarks.rdf"/>
+    <action command="delete" search="file" path="~/.config/epiphany/ephy-bookmarks.xml"/>
+    <action command="delete" search="file" path="~/.config/epiphany/ephy-history.db"/>
+    <action command="delete" search="file" path="~/.config/epiphany/session_state.xml"/>
+    <action command="delete" search="file" path="~/.config/epiphany/session_state.xml~"/>
+  </option>
+  <option id="dom">
+    <label>DOM Storage</label>
+    <description>Delete HTML5 cookies</description>
+    <action command="delete" search="walk.file" path="~/.local/share/webkitgtk/localstorage/"/>
   </option>
 </cleaner>


### PR DESCRIPTION
Added paths used by Epiphany 3.10.3 on Ubuntu GNOME 14.04.
I was unable to find lock file.
Passwords are saved in GNOME Keyring.