### PR TITLE
Update Rhythmbox Cleaner

### DIFF
--- a/cleaners/rhythmbox.xml
+++ b/cleaners/rhythmbox.xml
@@ -27,4 +27,9 @@
     <action command="delete" search="walk.files" path="~/.gnome2/rhythmbox/jamendo/"/>
     <action command="delete" search="walk.files" path="~/.gnome2/rhythmbox/magnatune/"/>
   </option>
+  <option id="history">
+    <label>Database</label>
+    <description>Delete database, which contain information such as play count and last played</description>
+    <action command="delete" search="file" path="~/.local/share/rhythmbox/rhythmdb.xml"/>
+  </option>
 </cleaner>


### PR DESCRIPTION
Added path used by Rhythmbox 3.0.2 on Ubuntu GNOME 14.04.
This database contain tags like: <mtime>, <first-seen>, <last-seen>, <play-count>, <last-played>.
Rhythmbox using it to index collection folder, after deleting it Rhythmbox need to index folder again and it can take some time.