### PR TITLE
Update Transmission Cleaner

### DIFF
--- a/cleaners/transmission.xml
+++ b/cleaners/transmission.xml
@@ -35,4 +35,9 @@
     <action command="delete" search="walk.files" path="~/.config/transmission/resume/"/>
     <action command="delete" search="walk.files" path="~/.config/transmission/torrents/"/>
   </option>
+  <option id="history">
+    <label>Statistics</label>
+    <description>Delete statistics such as ammount of downloaded/uploaded data and session count</description>
+    <action command="delete" search="file" path="~/.config/transmission/stats.json"/>
+  </option>
 </cleaner>


### PR DESCRIPTION
Added path used by Transmission 2.82 on Ubuntu GNOME 14.04.