### PR TITLE
Update GNOME Cleaner

### DIFF
--- a/cleaners/gnome.xml
+++ b/cleaners/gnome.xml
@@ -33,5 +33,6 @@
     <description>Delete the search history</description>
     <!-- In GNOME 2.26.3 on Fedora 11 click Places (toolbar) - Search For Files, and then click the down arrow -->
     <action command="delete" search="file" path="~/.gconf/apps/gnome-settings/gnome-search-tool/%gconf.xml"/>
+    <action command="delete" search="file" path="~/.local/share/gnome-shell/application_state"/>
   </option>
 </cleaner>


### PR DESCRIPTION
Added path used by GNOME Shell 3.10.4 on Ubuntu GNOME 14.04.
It is probably used for more accurate application searches.
It have data entries like this "<application id="nautilus.desktop" open-window-count="2" score="2315.25" last-seen="1460991182"/>".