### PR TITLE
Add normalized_walk function to DeepScan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ install:
   - cd ..
 # coveralls.io
   - pip install python-coveralls requests[security]
+# install mock
+  - pip install mock
 script: make tests COVERAGE="coverage run --include='bleachbit/*'"
 after_success:
    - coverage report

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,6 +42,7 @@ cache:
 test_script:
 # shorten very long path because of error https://github.com/az0/bleachbit/issues/166
   - 'set PATH=c:\windows\system32;c:\windows;c:\windows\system32\wbem'
+  - '%PYTHON_HOME%/Scripts/pip.exe install mock'
   - '%PYTHON_HOME%/python.exe tests/TestAll.py'
 
 artifacts:


### PR DESCRIPTION
Prior to this normalizing was done in a function that was called in a busy loop. That function call checked `sys.platform` and then normalized a filename. This commit moves the function call and `sys.platform` check out of the loop by creating a new `normalized_walk` function which is like `os.walk` but does the normalization efficiently.

This issue was called out in a previous pull request: https://github.com/az0/bleachbit/pull/139/files#r69675085.
