### PR TITLE
localizations.xml: Allow patterns in foldernames

### DIFF
--- a/bleachbit/Unix.py
+++ b/bleachbit/Unix.py
@@ -39,11 +39,68 @@ import FileUtilities
 import General
 
 
-class Locales:
+class LocaleCleanerPath:
+    """This represents a path with either a specific folder name or a folder name pattern.
+    It also may contain several compiled regex patterns for localization items (folders or files)
+    and additional LocaleCleanerPaths that get traversed when asked to supply a list of localization
+    items"""
 
+    def __init__(self, location):
+        if location is None:
+            raise RuntimeError("location is none")
+        self.pattern = location
+        self.children = []
+
+    def add_child(self, child):
+        """Adds a child LocaleCleanerPath"""
+        self.children.append(child)
+        return child
+
+    def add_path_filter(self, pre, post):
+        """Adds a filter consisting of a prefix and a postfix
+        (e.g. 'foobar_' and '\.qm' to match 'foobar_en_US.utf-8.qm)"""
+        try:
+            regex = re.compile('^' + pre + Locales.localepattern + post + '$')
+        except Exception as errormsg:
+            raise RuntimeError("Malformed regex '%s' or '%s': %s" % (pre, post, errormsg))
+        self.add_child(regex)
+
+    def get_subpaths(self, basepath):
+        """Returns direct subpaths for this object, i.e. either the named subfolder or all
+        subfolders matching the pattern"""
+        if isinstance(self.pattern, re._pattern_type):
+            return (os.path.join(basepath, p) for p in os.listdir(basepath)
+                    if self.pattern.match(p) and os.path.isdir(os.path.join(basepath, p)))
+        else:
+            path = os.path.join(basepath, self.pattern)
+            return [path] if os.path.isdir(path) else []
+
+    def get_localizations(self, basepath):
+        """Returns all localization items for this object and all descendant objects"""
+        for path in self.get_subpaths(basepath):
+            for child in self.children:
+                if isinstance(child, LocaleCleanerPath):
+                    for res in child.get_localizations(path):
+                        yield res
+                elif isinstance(child, re._pattern_type):
+                    for element in os.listdir(path):
+                        match = child.match(element)
+                        if match is not None:
+                            yield (match.group('locale'), os.path.join(path, element))
+
+
+class Locales:
     """Find languages and localization files"""
 
-    localepattern = r"(?P<locale>[a-z]{2,3})(?:[_-][a-zA-Z]{2,4})?(?:\.[a-zA-Z0-9-]*)?(?:@[a-zA-Z]*)?"
+    # The regular expression to match locale strings and extract the langcode.
+    # See test_locale_regex() in tests/TestUnix.py for examples
+    # This doesn't match all possible valid locale strings to avoid
+    # matching filenames you might want to keep, e.g. the regex
+    # to match jp.eucJP might also match jp.importantfileextension
+    localepattern =\
+        r'(?P<locale>[a-z]{2,3})' \
+        r'(?:[_-][A-Z]{2,4}(?:\.[\w]+[\d-]+|@\w+)?)?' \
+        r'(?P<encoding>[.-_](?:(?:ISO|iso|UTF|utf)[\d-]+|(?:euc|EUC)[A-Z]+))?'
 
     native_locale_names = \
         {'aa': 'Afaraf',
@@ -261,92 +318,64 @@ class Locales:
          'zh_TW': '中文',
          'zu': 'isiZulu'}
 
-    _paths = []
-
     def __init__(self):
-        pass
+        self._paths = LocaleCleanerPath(location='/')
 
-    def add_xml(self, xml_node):
-        self._paths.append(xml_node)
+    def add_xml(self, xml_node, parent=None):
+        """Parses the xml data and adds nodes to the LocaleCleanerPath-tree"""
+
+        if parent is None:
+            parent = self._paths
+        if xml_node.ELEMENT_NODE != xml_node.nodeType:
+            return
+
+        # if a pattern is supplied, we recurse into all matching subdirectories
+        if 'regexfilter' == xml_node.nodeName:
+            pre = xml_node.getAttribute('prefix') or ''
+            post = xml_node.getAttribute('postfix') or ''
+            parent.add_path_filter(pre, post)
+        elif 'path' == xml_node.nodeName:
+            if xml_node.hasAttribute('directoryregex'):
+                pattern = xml_node.getAttribute('directoryregex')
+                if '/' in pattern:
+                    raise RuntimeError('directoryregex may not contain slashes.')
+                pattern = re.compile(pattern)
+                parent = parent.add_child(LocaleCleanerPath(pattern))
+
+            # a combination of directoryregex and filter could be too much
+            else:
+                if xml_node.hasAttribute("location"):
+                    # if there's a filter attribute, it should apply to this path
+                    parent = parent.add_child(LocaleCleanerPath(xml_node.getAttribute('location')))
+
+                if xml_node.hasAttribute('filter'):
+                    userfilter = xml_node.getAttribute('filter')
+                    if 1 != userfilter.count('*'):
+                        raise RuntimeError(
+                            "Filter string '%s' must contain the placeholder * exactly once" % userfilter)
+
+                    # we can't use re.escape, because it escapes too much
+                    (pre, post) = (re.sub(r'([\[\]()^$.])', r'\\\1', p)
+                                   for p in userfilter.split('*'))
+                    parent.add_path_filter(pre, post)
+        else:
+            raise RuntimeError(
+                "Invalid node '%s', expected '<path>' or '<regexfilter>'" % xml_node.nodeName)
+
+        # handle child nodes
+        for child_xml in xml_node.childNodes:
+            self.add_xml(child_xml, parent)
 
     def localization_paths(self, locales_to_keep):
+        """Returns all localization items matching the previously added xml configuration"""
         if not locales_to_keep:
             raise RuntimeError('Found no locales to keep')
         purgeable_locales = frozenset((locale for locale in Locales.native_locale_names.keys()
                                        if locale not in locales_to_keep))
 
-        for xml_node in self._paths:
-            for (locale, path) in Locales.handle_path('', xml_node):
-                if locale in purgeable_locales:
-                    yield path
-
-    @staticmethod
-    def handle_path(path, xmldata):
-        """Extracts paths and filters from the supplied xml tree and yields matching files"""
-
-        if xmldata.ELEMENT_NODE != xmldata.nodeType:
-            return
-        if xmldata.nodeName not in ['path', 'regexfilter']:
-            raise RuntimeError(
-                "Invalid node '%s', expected '<path>' or '<regexfilter>'" % xmldata.nodeName)
-        location = xmldata.getAttribute('location') or '.'
-
-        # if a pattern is supplied, we recurse into all matching subdirectories
-        if xmldata.hasAttribute('pattern'):
-            pattern = xmldata.getAttribute('pattern')
-            if '/' in pattern:
-                raise RuntimeError('directory pattern may not contain slashes.')
-            pattern = re.compile(pattern)
-
-            for subpath in os.listdir(path):
-                if pattern.match(subpath) and os.path.isdir(path+subpath):
-                    subpath = path + subpath + '/'
-                    for child in xmldata.childNodes:
-                        for (l, s) in Locales.handle_path(subpath, child):
-                            yield (l, s)
-            return
-
-        if '.' != location:
-            path = path + location
-        if not path.endswith('/'):
-            path += '/'
-
-        if not os.path.isdir(path):
-            return
-
-        pre = None
-        post = None
-        if 'regexfilter' == xmldata.nodeName:
-            pre = xmldata.getAttribute('prefix') or ''
-            post = xmldata.getAttribute('postfix') or ''
-        elif 'path' == xmldata.nodeName:
-            userfilter = xmldata.getAttribute('filter')
-            if not userfilter and not xmldata.hasChildNodes():
-                userfilter = '*'
-            if userfilter:
-                if 1 != userfilter.count('*'):
-                    raise RuntimeError(
-                        "Filter string '%s' must contain the placeholder * exactly once" % userfilter)
-
-                # we can't use re.escape, because it escapes too much
-                (pre, post) = (re.sub(r'([\[\]()^$.])', r'\\\1', p)
-                               for p in userfilter.split('*'))
-            # handle child nodes
-            for child in xmldata.childNodes:
-                for (locale, subpath) in Locales.handle_path(path, child):
-                    yield (locale, subpath)
-        if pre is not None and post is not None:
-            try:
-                re.compile(pre)
-                re.compile(post)
-            except Exception as errormsg:
-                raise RuntimeError(
-                    "Malformed regex '%s' or '%s': %s" % (pre, post, errormsg))
-            regex = re.compile('^' + pre + Locales.localepattern + post + '$')
-            for subpath in os.listdir(path):
-                match = regex.match(subpath)
-                if match is not None:
-                    yield (match.group("locale"), path + subpath)
+        for (locale, path) in self._paths.get_localizations('/'):
+            if locale in purgeable_locales:
+                yield path
 
 
 def apt_autoclean():

--- a/cleaners/localizations.xml
+++ b/cleaners/localizations.xml
@@ -15,6 +15,12 @@
       </path>
     </path>
     <path location="/usr/share">
+      <!-- check for Qt translations in every folder's subfolder locale or translations -->
+      <path pattern="^.*$">
+        <path pattern="^(locale|translations)$">
+          <regexfilter prefix=".*_" postfix="\.qm"/>
+        </path>
+      </path>
       <!-- A <path> element without children and an explicit filter-attribute
            defaults to filter="*"-->
       <path location="anki/locale"/>
@@ -38,12 +44,12 @@
       <path location="lyx/examples"/>
       <path location="man"/>
       <path location="mathjax/localization"/>
-      <path location="mscore-2.0/locale">
-        <regexfilter prefix="(instruments|mscore|qt)_" postfix="\.qm"/>
+      <path location="octave/">
+        <path pattern="^[0-9.]+$">
+          <path location="locale/" filter="*.qm"/>
+        </path>
       </path>
-      <path location="qt4/translations">
-        <regexfilter prefix="\w*_" postfix="\.qm"/>
-      </path>
+      <!-- This already gets cleaned by the more general <path pattern="^.*$"> above but might be useful as an example -->
       <path location="qt/translations">
         <!-- <regexfilter> enables filtering files/folders with 2 regular expressions.
              This deletes every file matching |prefix | locale   | postfix, e.g.
@@ -54,9 +60,7 @@
         <regexfilter prefix="(linguist|designer|assistant)_" postfix="\.qm"/>
       </path>
       <path location="speedcrunch/books"/>
-      <path location="texmaker/" filter="*.dic">
-        <regexfilter prefix="(texmaker|qt)_" postfix="\.qm"/>
-      </path>
+      <path location="texmaker/" filter="*.dic"/>
       <path location="vim/vim74/lang" filter="menu_*.vim"/>
       <path location="vim/vim74/lang"/>
       <path location="X11/locale"/>

--- a/cleaners/localizations.xml
+++ b/cleaners/localizations.xml
@@ -16,55 +16,49 @@
     </path>
     <path location="/usr/share">
       <!-- check for Qt translations in every folder's subfolder locale or translations -->
-      <path pattern="^.*$">
-        <path pattern="^(locale|translations)$">
+      <!-- also check for localizations in folders named locale(s)/translation(s) in every subfolder-->
+      <path directoryregex="^.*$">
+        <path directoryregex="^(locale|translation)s?$">
           <regexfilter prefix=".*_" postfix="\.qm"/>
+          <path location="." filter="*"/>
         </path>
       </path>
-      <!-- A <path> element without children and an explicit filter-attribute
-           defaults to filter="*"-->
-      <path location="anki/locale"/>
-      <path location="apps/ksgmltools/customization"/>
-      <path location="calendar"/>
-      <path location="cups/doc"/>
-      <path location="cups/locale"/>
+      <path location="apps/ksgmltools/customization" filter="*"/>
+      <path location="calendar" filter="*"/>
+      <path location="cups/doc" filter="*"/>
       <path location="doc">
-        <path location="kde/HTML"/>
-        <path location="HTML/release-notes"/>
-        <path location="thunar-data/html"/>
+        <path location="kde/HTML" filter="*"/>
+        <path location="HTML/release-notes" filter="*"/>
+        <path location="thunar-data/html" filter="*"/>
       </path>
-      <path location="help"/>
-      <path location="i18n/locales"/>
-      <path location="locale"/>
+      <path location="help" filter="*"/>
+      <path location="locale" filter="*"/>
       <!-- for openSuSE -->
       <path location="locale-bundle">
-        <path location="kf5"/>
+        <path location="kf5" filter="*"/>
       </path>
-      <path location="lyx/doc"/>
-      <path location="lyx/examples"/>
-      <path location="man"/>
-      <path location="mathjax/localization"/>
+      <path location="lyx/doc" filter="*"/>
+      <path location="lyx/examples" filter="*"/>
+      <path location="man" filter="*"/>
       <path location="octave/">
-        <path pattern="^[0-9.]+$">
+        <path directoryregex="^[0-9.]+$">
           <path location="locale/" filter="*.qm"/>
         </path>
       </path>
-      <!-- This already gets cleaned by the more general <path pattern="^.*$"> above but might be useful as an example -->
+      <!-- This already gets cleaned by the more general <path directoryregex="^.*$"> above but might be useful as an example -->
       <path location="qt/translations">
         <!-- <regexfilter> enables filtering files/folders with 2 regular expressions.
-             This deletes every file matching |prefix | locale   | postfix, e.g.
-                                              qt_help_hu_HU.UTF-8.qm
-             This can only be used to delete entries in the current <path> -->
+           This deletes every file matching |prefix | locale   | postfix, e.g.
+                                             qt_help_hu_HU.UTF-8.qm
+           This can only be used to delete entries in the current <path> -->
         <regexfilter prefix="q[\w_]*" postfix="\.qm"/>
         <!-- You can also specify multiple <regexfilter>s within a single path -->
         <regexfilter prefix="(linguist|designer|assistant)_" postfix="\.qm"/>
       </path>
-      <path location="speedcrunch/books"/>
+      <path location="speedcrunch/books" filter="*"/>
       <path location="texmaker/" filter="*.dic"/>
       <path location="vim/vim74/lang" filter="menu_*.vim"/>
-      <path location="vim/vim74/lang"/>
-      <path location="X11/locale"/>
-      <path location="zenmap/locale"/>
+      <path location="vim/vim74/lang" filter="*"/>
     </path>
   </localizations>
 </cleaner>

--- a/doc/cleaner_markup_language.xsd
+++ b/doc/cleaner_markup_language.xsd
@@ -170,7 +170,7 @@
           </xs:complexType>
         </xs:element>
       </xs:choice>
-      <xs:attribute name="pattern" type="xs:string" use="optional"/>
+      <xs:attribute name="directoryregex" type="xs:string" use="optional"/>
       <xs:attribute name="location" type="xs:string" use="optional" default="."/>
       <xs:attribute name="filter" type="xs:string" use="optional" default="*"/>
     </xs:complexType>

--- a/doc/cleaner_markup_language.xsd
+++ b/doc/cleaner_markup_language.xsd
@@ -170,6 +170,7 @@
           </xs:complexType>
         </xs:element>
       </xs:choice>
+      <xs:attribute name="pattern" type="xs:string" use="optional"/>
       <xs:attribute name="location" type="xs:string" use="optional" default="."/>
       <xs:attribute name="filter" type="xs:string" use="optional" default="*"/>
     </xs:complexType>

--- a/tests/TestUnix.py
+++ b/tests/TestUnix.py
@@ -153,7 +153,7 @@ root               531   0.0  0.0  2501712    588   ??  Ss   20May16   0:02.40 s
         for path in keepdirs + nukedirs:
             os.mkdir(os.path.join(dirname, path))
         for path in keepfiles + nukefiles:
-            open(os.path.join(path, file), 'w').close()
+            open(os.path.join(dirname, path), 'w').close()
 
         configxml = '<path directoryregex="^.*$">' \
                     '  <path directoryregex="^(locale|dummyfiles)$">' \

--- a/tests/TestUnix.py
+++ b/tests/TestUnix.py
@@ -26,6 +26,7 @@ Test case for module Unix
 
 import os
 import sys
+import tempfile
 import unittest
 
 sys.path.append('.')
@@ -96,16 +97,17 @@ root               531   0.0  0.0  2501712    588   ??  Ss   20May16   0:02.40 s
                  ('en_US', 'en'),
                  ('en_US@piglatin', 'en'),
                  ('en_US.utf8', 'en'),
+                 ('ko_KR.eucKR', 'ko'),
                  ('pl.ISO8859-2', 'pl'),
-                 ('sr_Latn', 'sr'),
                  ('zh_TW.Big5', 'zh')]
         import re
         regex = re.compile('^' + Locales.localepattern + '$')
         for test in tests:
             m = regex.match(test[0])
+            self.assertIsNotNone(m, 'expected positive match for ' + test[0])
             self.assertEqual(m.group("locale"), test[1])
-        for test in ['default', 'C', 'English']:
-            self.assertTrue(regex.match('test') is None)
+        for test in ['default', 'C', 'English', 'ru_RU.txt', 'ru.txt']:
+            self.assertIsNone(regex.match(test), 'expected negative match for '+test)
 
     def test_localization_paths(self):
         """Unit test for localization_paths()"""
@@ -121,7 +123,55 @@ root               531   0.0  0.0  2501712    588   ??  Ss   20May16   0:02.40 s
             self.assert_(path.find('/en_') == -1)
             counter += 1
         self.assert_(
-            counter > 0, 'Zero files deleted by localization cleaner.  This may be an error unless you really deleted all the files.')
+            counter > 0, 'Zero files deleted by localization cleaner.'
+                         'This may be an error unless you really deleted all the files.')
+
+    def test_fakelocalizationdirs(self):
+        """Create a faked localization hierarchy and clean it afterwards"""
+        dirname = tempfile.mkdtemp(prefix='bleachbit-test-localizations')
+
+        keepdirs = [
+            'important_dontdelete',
+            'important_dontdelete/ru',
+            'delete',
+            'delete/locale',
+            'delete/locale/en',
+            'delete/dummyfiles',
+            'foobar',
+            'foobar/locale']
+        nukedirs = [
+            'delete/locale/ru',
+            'foobar/locale/ru']
+        keepfiles = [
+            'delete/dummyfiles/dontdeleteme_ru.txt',
+            'important_dontdelete/exceptthisone_ru.txt',
+            'delete/dummyfiles/en.txt',
+            'delete/dummyfiles/ru.dic']
+        nukefiles = [
+            'delete/dummyfiles/ru.txt',
+            'delete/locale/ru_RU.UTF8.txt']
+        for path in keepdirs + nukedirs:
+            os.mkdir(os.path.join(dirname, path))
+        for path in keepfiles + nukefiles:
+            open(os.path.join(path, file), 'w').close()
+
+        configxml = '<path directoryregex="^.*$">' \
+                    '  <path directoryregex="^(locale|dummyfiles)$">' \
+                    '    <path location="." filter="*" />' \
+                    '    <regexfilter postfix="\.txt" />' \
+                    '  </path>' \
+                    '</path>'
+        from xml.dom.minidom import parseString
+        config = parseString(configxml)
+        locales = Locales()
+        locales._paths = LocaleCleanerPath(dirname)
+        locales.add_xml(config.firstChild, None)
+        # normpath because paths may contain ./
+        deletelist = [os.path.normpath(path) for path in locales.localization_paths(['en', 'de'])]
+        for path in keepdirs + keepfiles:
+            self.assertNotIn(os.path.join(dirname, path), deletelist)
+        for path in nukedirs + nukefiles:
+            self.assertIn(os.path.join(dirname, path), deletelist)
 
     def test_rotated_logs(self):
         """Unit test for rotated_logs()"""

--- a/tests/TestUnix.py
+++ b/tests/TestUnix.py
@@ -104,10 +104,10 @@ root               531   0.0  0.0  2501712    588   ??  Ss   20May16   0:02.40 s
         regex = re.compile('^' + Locales.localepattern + '$')
         for test in tests:
             m = regex.match(test[0])
-            self.assertIsNotNone(m, 'expected positive match for ' + test[0])
+            self.assert_(m is not None, 'expected positive match for ' + test[0])
             self.assertEqual(m.group("locale"), test[1])
         for test in ['default', 'C', 'English', 'ru_RU.txt', 'ru.txt']:
-            self.assertIsNone(regex.match(test), 'expected negative match for '+test)
+            self.assert_(regex.match(test) is None, 'expected negative match for '+test)
 
     def test_localization_paths(self):
         """Unit test for localization_paths()"""
@@ -169,9 +169,9 @@ root               531   0.0  0.0  2501712    588   ??  Ss   20May16   0:02.40 s
         # normpath because paths may contain ./
         deletelist = [os.path.normpath(path) for path in locales.localization_paths(['en', 'de'])]
         for path in keepdirs + keepfiles:
-            self.assertNotIn(os.path.join(dirname, path), deletelist)
+            self.assert_(os.path.join(dirname, path) not in deletelist)
         for path in nukedirs + nukefiles:
-            self.assertIn(os.path.join(dirname, path), deletelist)
+            self.assert_(os.path.join(dirname, path) in deletelist)
 
     def test_rotated_logs(self):
         """Unit test for rotated_logs()"""


### PR DESCRIPTION
Many Qt programs store their localizations in `/usr/share/XY/translations/XY_en.qm` instead of in `/usr/share/locale/en/XY`.
This PR adds a new attribute `pattern` to `<path>` elements which recurses into all matching folders.