### PR TITLE
journald cleaner

### DIFF
--- a/bleachbit/Action.py
+++ b/bleachbit/Action.py
@@ -340,8 +340,8 @@ class Journald(ActionProvider):
     """Action to run 'journalctl --vacuum-time=1'"""
     action_key = 'journald.clean'
 
-    def __init__(self, action_element, action_node):
-        super(Journald, self).__init__(action_node)
+    def __init__(self, action_element):
+        pass
 
     def get_commands(self):
         if FileUtilities.exe_exists('journalctl'):

--- a/bleachbit/Action.py
+++ b/bleachbit/Action.py
@@ -336,6 +336,18 @@ class Ini(FileActionProvider):
             yield Command.Ini(path, self.section, self.parameter)
 
 
+class Journald(ActionProvider):
+    """Action to run 'journalctl --vacuum-time=1'"""
+    action_key = 'journald.clean'
+
+    def __init__(self, action_element, action_node):
+        super(Journald, self).__init__(action_node)
+
+    def get_commands(self):
+        if FileUtilities.exe_exists('journalctl'):
+            yield Command.Function(None, Unix.journald_clean, 'journalctl --vacuum-time=1')
+
+
 class Json(FileActionProvider):
 
     """Action to clean JSON configuration files"""

--- a/bleachbit/FileUtilities.py
+++ b/bleachbit/FileUtilities.py
@@ -479,20 +479,25 @@ def human_to_bytes(human, hformat='si'):
     """Convert a string like 10.2GB into bytes.  By
     default use SI standard (base 10).  The format of the
     GNU command 'du' (base 2) also supported."""
+
     if 'si' == hformat:
-        multiplier = {'B': 1, 'kB': 1000, 'MB': 1000 ** 2,
-                      'GB': 1000 ** 3, 'TB': 1000 ** 4}
-        matches = re.findall("^([0-9]*)(\.[0-9]{1,2})?([kMGT]{0,1}B)$", human)
+        base = 1000
+        suffixes = 'kMGTE'
     elif 'du' == hformat:
-        multiplier = {'B': 1, 'KB': 1024, 'MB': 1024 ** 2,
-                      'GB': 1024 ** 3, 'TB': 1024 ** 4}
-        matches = re.findall("^([0-9]*)(\.[0-9]{1,2})?([KMGT]{0,1}B)$", human)
+        base = 1024
+        suffixes = 'KMGTE'
     else:
         raise ValueError("Invalid format: '%s'" % hformat)
-    if [] == matches or 2 > len(matches[0]):
-        raise ValueError(
-            "Invalid input for '%s' (hformat='%s')" % (human, hformat))
-    return int(float(matches[0][0] + matches[0][1]) * multiplier[matches[0][2]])
+    matches = re.match(r'^(\d+(?:\.\d+)?) ?([' + suffixes + ']?)B?$', human)
+    if matches is None:
+        raise ValueError("Invalid input for '%s' (hformat='%s')" % (human, hformat))
+    (amount, suffix) = matches.groups()
+
+    if '' == suffix:
+        exponent = 0
+    else:
+        exponent = suffixes.find(suffix) + 1
+    return int(float(amount) * base**exponent)
 
 
 def listdir(directory):

--- a/bleachbit/Unix.py
+++ b/bleachbit/Unix.py
@@ -560,19 +560,19 @@ def wine_to_linux_path(wineprefix, windows_pathname):
     return os.path.join(wineprefix, windows_pathname)
 
 
-def run_cleaner_cmd(bin, args, freed_space_regex=r'[\d.]+[kMGTE]?B?', error_line_regexes=None):
+def run_cleaner_cmd(cmd, args, freed_space_regex=r'[\d.]+[kMGTE]?B?', error_line_regexes=None):
     """Runs a specified command and returns how much space was (reportedly) freed.
     The subprocess shouldn't need any user input and the user should have the
     necessary rights.
     freed_space_regex gets applied to every output line, if the re matches,
     add values captured by the single group in the regex"""
-    if not FileUtilities.exe_exists(bin):
-        raise RuntimeError(_('Executable not found: %s') % bin)
+    if not FileUtilities.exe_exists(cmd):
+        raise RuntimeError(_('Executable not found: %s') % cmd)
     freed_space_regex = re.compile(freed_space_regex)
     error_line_regexes = [re.compile(regex) for regex in error_line_regexes or []]
 
-    output = subprocess.check_output([bin]+args, stderr=subprocess.STDOUT,
-                                     universal_newlines=True, env={'LC_ALL':'C'})
+    output = subprocess.check_output([cmd]+args, stderr=subprocess.STDOUT,
+                                     universal_newlines=True, env={'LC_ALL': 'C'})
 
     freed_space = 0
     for line in output.split('\n'):
@@ -581,7 +581,7 @@ def run_cleaner_cmd(bin, args, freed_space_regex=r'[\d.]+[kMGTE]?B?', error_line
             freed_space += FileUtilities.human_to_bytes(m.group(1))
         for error_re in error_line_regexes:
             if error_re.search(line):
-                raise RuntimeError('Invalid output from %s: %s' % (bin,line))
+                raise RuntimeError('Invalid output from %s: %s' % (cmd, line))
 
     return freed_space
 
@@ -589,7 +589,7 @@ def run_cleaner_cmd(bin, args, freed_space_regex=r'[\d.]+[kMGTE]?B?', error_line
 def journald_clean():
     """Clean the system journals"""
     freed_space_regex = '^Vacuuming done, freed ([\d.]+[KMGT]?) of archived journals on disk.$'
-    return run_cleaner_cmd('journalctl',['--vacuum-size=1'], freed_space_regex)
+    return run_cleaner_cmd('journalctl', ['--vacuum-size=1'], freed_space_regex)
 
 
 def apt_autoremove():

--- a/bleachbit/Unix.py
+++ b/bleachbit/Unix.py
@@ -24,7 +24,6 @@ Integration specific to Unix-like operating systems
 """
 
 import glob
-import math
 import os
 import re
 import shlex
@@ -376,67 +375,6 @@ class Locales:
                 yield path
 
 
-def apt_autoclean():
-    """Run 'apt-get autoclean' and return the size (un-rounded, in bytes)
-        of freed space"""
-
-    if not FileUtilities.exe_exists('apt-get'):
-        raise RuntimeError(_('Executable not found: %s') % 'apt-get')
-
-    args = ['apt-get', 'autoclean']
-
-    process = subprocess.Popen(args,
-                               stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
-
-    total_bytes = 0
-
-    while True:
-        line = process.stdout.readline().replace("\n", "")
-        if line.startswith('E: '):
-            raise RuntimeError(line)
-        # Del cups-common 1.3.9-17ubuntu3 [1165kB]
-        match = re.search("^Del .*\[([0-9.]+[a-zA-Z]{2})\]", line)
-        if match:
-            pkg_bytes_str = match.groups(0)[0]
-            pkg_bytes = FileUtilities.human_to_bytes(pkg_bytes_str.upper())
-            total_bytes += pkg_bytes
-        if "" == line and process.poll() is not None:
-            break
-
-    return total_bytes
-
-
-def apt_autoremove():
-    """Run 'apt-get autoremove' and return the size (un-rounded, in bytes)
-        of freed space"""
-
-    if not FileUtilities.exe_exists('apt-get'):
-        raise RuntimeError(_('Executable not found: %s') % 'apt-get')
-
-    args = ['apt-get', '--yes', 'autoremove']
-
-    process = subprocess.Popen(args,
-                               stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
-
-    total_bytes = 0
-
-    while True:
-        line = process.stdout.readline().replace("\n", "")
-        if line.startswith('E: '):
-            raise RuntimeError(line)
-        # After this operation, 74.7MB disk space will be freed.
-        match = re.search(
-            r", ([0-9.]+[a-zA-Z]{2}) disk space will be freed", line)
-        if match:
-            pkg_bytes_str = match.groups(0)[0]
-            pkg_bytes = FileUtilities.human_to_bytes(pkg_bytes_str.upper())
-            total_bytes += pkg_bytes
-        if "" == line and process.poll() is not None:
-            break
-
-    return total_bytes
-
-
 def __is_broken_xdg_desktop_application(config, desktop_pathname):
     """Returns boolean whether application deskop entry file is broken"""
     if not config.has_option('Desktop Entry', 'Exec'):
@@ -622,7 +560,7 @@ def wine_to_linux_path(wineprefix, windows_pathname):
     return os.path.join(wineprefix, windows_pathname)
 
 
-def run_cleaner_cmd(bin, args, freed_space_regex=r'[\d.]+[kMTGTE]?B?', error_line_regexes=[]):
+def run_cleaner_cmd(bin, args, freed_space_regex=r'[\d.]+[kMGTE]?B?', error_line_regexes=None):
     """Runs a specified command and returns how much space was (reportedly) freed.
     The subprocess shouldn't need any user input and the user should have the
     necessary rights.
@@ -631,7 +569,7 @@ def run_cleaner_cmd(bin, args, freed_space_regex=r'[\d.]+[kMTGTE]?B?', error_lin
     if not FileUtilities.exe_exists(bin):
         raise RuntimeError(_('Executable not found: %s') % bin)
     freed_space_regex = re.compile(freed_space_regex)
-    error_line_regexes = [re.compile(regex) for regex in error_line_regexes]
+    error_line_regexes = [re.compile(regex) for regex in error_line_regexes or []]
 
     output = subprocess.check_output([bin]+args, stderr=subprocess.STDOUT,
                                      universal_newlines=True, env={'LC_ALL':'C'})
@@ -654,37 +592,32 @@ def journald_clean():
     return run_cleaner_cmd('journalctl',['--vacuum-size=1'], freed_space_regex)
 
 
+def apt_autoremove():
+    """Run 'apt-get autoremove' and return the size (un-rounded, in bytes)
+        of freed space"""
+
+    args = ['--yes', 'autoremove']
+    # After this operation, 74.7MB disk space will be freed.
+    return run_cleaner_cmd('apt-get', args, r', ([\d.]+[a-zA-Z]{2}) disk space will be freed', ['^E: '])
+
+
+def apt_autoclean():
+    """Run 'apt-get autoclean' and return the size (un-rounded, in bytes)
+        of freed space"""
+    return run_cleaner_cmd('apt-get', ['autoclean'], r'^Del .*\[([\d.]+[a-zA-Z]{2})}]', ['^E: '])
+
+
 def yum_clean():
     """Run 'yum clean all' and return size in bytes recovered"""
     if os.path.exists('/var/run/yum.pid'):
         msg = _(
             "%s cannot be cleaned because it is currently running.  Close it, and try again.") % "Yum"
         raise RuntimeError(msg)
-    if not FileUtilities.exe_exists('yum'):
-        raise RuntimeError(_('Executable not found: %s') % 'yum')
+
     old_size = FileUtilities.getsizedir('/var/cache/yum')
-    args = ['yum', "--enablerepo=*", 'clean', 'all']
-    p = subprocess.Popen(args, stderr=subprocess.STDOUT,
-                         stdout=subprocess.PIPE)
-    non_blank_line = ""
-    while True:
-        line = p.stdout.readline().replace("\n", "")
-        if len(line) > 2:
-            non_blank_line = line
-        if -1 != line.find('You need to be root'):
-            # Seen before Fedora 13
-            raise RuntimeError(line)
-        if -1 != line.find('Cannot remove rpmdb file'):
-            # Since first in Fedora 13
-            raise RuntimeError(line)
-        if -1 != line.find('Another app is currently holding'):
-            logger.debug("yum: '%s'" % line)
-            old_size = FileUtilities.getsizedir('/var/cache/yum')
-        if "" == line and p.poll() is not None:
-            break
-    logger.debug('yum process return code = %d' % p.returncode)
-    if p.returncode > 0:
-        raise RuntimeError(non_blank_line)
+    args = ['--enablerepo=*', 'clean', 'all']
+    invalid = ['You need to be root', 'Cannot remove rpmdb file']
+    run_cleaner_cmd('yum', args, '^unused regex$', invalid)
     new_size = FileUtilities.getsizedir('/var/cache/yum')
     return old_size - new_size
 

--- a/bleachbit/Unix.py
+++ b/bleachbit/Unix.py
@@ -24,6 +24,7 @@ Integration specific to Unix-like operating systems
 """
 
 import glob
+import math
 import os
 import re
 import shlex
@@ -619,6 +620,38 @@ def wine_to_linux_path(wineprefix, windows_pathname):
                                                 "drive_" + drive_letter.lower())
     windows_pathname = windows_pathname.replace("\\", "/")
     return os.path.join(wineprefix, windows_pathname)
+
+
+def run_cleaner_cmd(bin, args, freed_space_regex=r'[\d.]+[kMTGTE]?B?', error_line_regexes=[]):
+    """Runs a specified command and returns how much space was (reportedly) freed.
+    The subprocess shouldn't need any user input and the user should have the
+    necessary rights.
+    freed_space_regex gets applied to every output line, if the re matches,
+    add values captured by the single group in the regex"""
+    if not FileUtilities.exe_exists(bin):
+        raise RuntimeError(_('Executable not found: %s') % bin)
+    freed_space_regex = re.compile(freed_space_regex)
+    error_line_regexes = [re.compile(regex) for regex in error_line_regexes]
+
+    output = subprocess.check_output([bin]+args, stderr=subprocess.STDOUT,
+                                     universal_newlines=True, env={'LC_ALL':'C'})
+
+    freed_space = 0
+    for line in output.split('\n'):
+        m = freed_space_regex.match(line)
+        if m is not None:
+            freed_space += FileUtilities.human_to_bytes(m.group(1))
+        for error_re in error_line_regexes:
+            if error_re.search(line):
+                raise RuntimeError('Invalid output from %s: %s' % (bin,line))
+
+    return freed_space
+
+
+def journald_clean():
+    """Clean the system journals"""
+    freed_space_regex = '^Vacuuming done, freed ([\d.]+[KMGT]?) of archived journals on disk.$'
+    return run_cleaner_cmd('journalctl',['--vacuum-size=1'], freed_space_regex)
 
 
 def yum_clean():

--- a/cleaners/journald.xml
+++ b/cleaners/journald.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    BleachBit
+    Copyright (C) 2008-2016 Andrew Ziem, nodiscc
+    https://www.bleachbit.org
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<cleaner id="journald" os="linux">
+  <label>journald</label>
+  <description>System Journals</description>
+  <running type="exe">journalctl</running>
+  <option id="clean">
+    <label translate="false">clean</label>
+    <description>Clean old system journals</description>
+    <action command="journald.clean"/>
+  </option>
+</cleaner>

--- a/doc/cleaner_markup_language.xsd
+++ b/doc/cleaner_markup_language.xsd
@@ -98,6 +98,7 @@
                             <xs:enumeration value="chrome.keywords"/>
                             <xs:enumeration value="delete"/>
                             <xs:enumeration value="ini"/>
+                            <xs:enumeration value="journald.clean"/>
                             <xs:enumeration value="json"/>
                             <xs:enumeration value="mozilla_url_history"/>
                             <xs:enumeration value="office_registrymodifications"/>

--- a/tests/TestAll.py
+++ b/tests/TestAll.py
@@ -61,7 +61,7 @@ suites = [TestAction.suite(),
           TestUpdate.suite(),
           TestWorker.suite()]
 
-if 'posix' == os.name:
+if 'posix' == os.name and sys.version_info >= (2,7,0):
     import TestUnix
     suites.append(TestUnix.suite())
 

--- a/tests/TestFileUtilities.py
+++ b/tests/TestFileUtilities.py
@@ -553,6 +553,27 @@ class FileUtilitiesTestCase(unittest.TestCase):
         for path in guess_overwrite_paths():
             self.assert_(os.path.isdir(path), '%s is not a directory' % path)
 
+    def test_human_to_bytes(self):
+        """Unit test for human_to_bytes()"""
+        self.assertRaises(ValueError, human_to_bytes, '', hformat='invalid')
+
+        invalid = ['Bazillion kB',
+                   '120XB',
+                   '.12MB']
+        for test in invalid:
+            self.assertRaises(ValueError, human_to_bytes, test)
+
+        valid = {'1kB': 1000,
+                 '1.1MB': 1100000,
+                 '12B': 12,
+                 '1.0M': 1000*1000,
+                 '1TB': 1000**4,
+                 '1000': 1000}
+        for test, result in valid.items():
+            self.assertEqual(human_to_bytes(test), result)
+
+        self.assertEqual(human_to_bytes('1 MB', 'du'), 1024*1024)
+
     def test_listdir(self):
         """Unit test for listdir()"""
         for pathname in listdir(('/tmp', '~/.config/')):

--- a/tests/TestUnix.py
+++ b/tests/TestUnix.py
@@ -186,7 +186,9 @@ root               531   0.0  0.0  2501712    588   ??  Ss   20May16   0:02.40 s
                          "Rotated log path '%s' does not exist" % path)
 
     def test_run_cleaner_cmd(self):
+        from subprocess import CalledProcessError
         self.assertRaises(RuntimeError, run_cleaner_cmd, '/hopethisdoesntexist', [])
+        self.assertRaises(CalledProcessError, run_cleaner_cmd, 'sh', ['-c', 'echo errormsg; false'])
         # test if regexes for invalid lines work
         self.assertRaises(RuntimeError, run_cleaner_cmd, 'echo', ['This is an invalid line'],
                           error_line_regexes=['invalid'])

--- a/tests/TestUnix.py
+++ b/tests/TestUnix.py
@@ -94,7 +94,8 @@ root               531   0.0  0.0  2501712    588   ??  Ss   20May16   0:02.40 s
     def test_journald_clean(self):
         if not FileUtilities.exe_exists('journalctl'):
             self.assertRaises(RuntimeError,journald_clean)
-        journald_clean()
+        else:
+            journald_clean()
 
     def test_locale_regex(self):
         """Unit test for locale_to_language()"""

--- a/tests/TestUnix.py
+++ b/tests/TestUnix.py
@@ -42,12 +42,15 @@ class UnixTestCase(unittest.TestCase):
         """Initialize unit tests"""
         self.locales = Locales()
 
-    def test_apt_autoclean(self):
-        """Unit test for method apt_autoclean()"""
+    def test_apt(self):
+        """Unit test for method apt_autoclean() and apt_autoremove()"""
         if 0 != os.geteuid() or not FileUtilities.exe_exists('apt-get'):
             self.assertRaises(RuntimeError, apt_autoclean)
+            self.assertRaises(RuntimeError, apt_autoremove)
         else:
             bytes_freed = apt_autoclean()
+            self.assert_(isinstance(bytes_freed, (int, long)))
+            bytes_freed = apt_autoremove()
             self.assert_(isinstance(bytes_freed, (int, long)))
 
     def test_is_broken_xdg_desktop(self):


### PR DESCRIPTION
This also adds a generic binary runner, when I've got time I'll rewrite the yum and apt cleaners to use it.
`FileUtilities.human_to_bytes()` also got a bit more liberal, since journalctl reports freed space as `12.0M`, but with the new test this should be no problem.
